### PR TITLE
Update Readme with help output and add log to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.log

--- a/README.md
+++ b/README.md
@@ -4,4 +4,18 @@ Yet Another gdb TUI. Connect remotely with gdb when you don't have a working `gd
 * **No gdbserver requirements**: Many vendors ship invalid `gdbserver` binaries, this works on remote targets with just `gdb`, `nc`, and `mkfifo`.
 * **No python requirements**: Many vendors ship `gdb` without python support
 
+```
+Yet Another GDB TUI
+
+Usage: heretek [OPTIONS]
+
+Options:
+  -l, --local            Run gdb as child process from PATH
+  -r, --remote <REMOTE>  Connect to nc session
+      --32               Switch into 32-bit mode
+  -h, --help             Print help (see more with '--help')
+  -V, --version          Print version 
+
+```
+
 ![screenshot](images/screenshot.png)


### PR DESCRIPTION
Basically title.
`app.log` was in files visible to git so added to ignore to avoid possible contamination.

Closes #34 