### PR TITLE
perf: Avoid re-alloc for stack and asm

### DIFF
--- a/src/gdb.rs
+++ b/src/gdb.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,7 +30,7 @@ pub fn gdb_interact(
     register_names_arc: Arc<Mutex<Vec<String>>>,
     registers_arc: Arc<Mutex<Vec<RegisterStorage>>>,
     current_pc_arc: Arc<Mutex<u64>>,
-    stack_arc: Arc<Mutex<HashMap<u64, Deref>>>,
+    stack_arc: Arc<Mutex<BTreeMap<u64, Deref>>>,
     asm_arc: Arc<Mutex<Vec<Asm>>>,
     output_arc: Arc<Mutex<Vec<String>>>,
     stream_output_prompt_arc: Arc<Mutex<String>>,
@@ -172,7 +172,7 @@ fn exec_result_done(
 }
 
 fn exec_result_running(
-    stack_arc: &Arc<Mutex<HashMap<u64, Deref>>>,
+    stack_arc: &Arc<Mutex<BTreeMap<u64, Deref>>>,
     asm_arc: &Arc<Mutex<Vec<Asm>>>,
     registers_arc: &Arc<Mutex<Vec<RegisterStorage>>>,
     hexdump_arc: &Arc<Mutex<Option<(u64, Vec<u8>)>>>,
@@ -335,7 +335,7 @@ fn recv_exec_result_asm_insns(
     asm: &String,
     asm_arc: &Arc<Mutex<Vec<Asm>>>,
     registers_arc: &Arc<Mutex<Vec<RegisterStorage>>>,
-    stack_arc: &Arc<Mutex<HashMap<u64, Deref>>>,
+    stack_arc: &Arc<Mutex<BTreeMap<u64, Deref>>>,
     written: &mut VecDeque<Written>,
 ) {
     if written.is_empty() {
@@ -384,7 +384,7 @@ fn recv_exec_result_asm_insns(
 
 /// MIResponse::ExecResult, key: "memory"
 fn recv_exec_result_memory(
-    stack_arc: &Arc<Mutex<HashMap<u64, Deref>>>,
+    stack_arc: &Arc<Mutex<BTreeMap<u64, Deref>>>,
     thirty_two_bit: &Arc<AtomicBool>,
     endian_arc: &Arc<Mutex<Option<Endian>>>,
     registers_arc: &Arc<Mutex<Vec<RegisterStorage>>>,
@@ -522,7 +522,7 @@ fn update_stack(
     thirty_two_bit: &Arc<AtomicBool>,
     endian_arc: &Arc<Mutex<Option<Endian>>>,
     begin: String,
-    stack: &mut std::sync::MutexGuard<HashMap<u64, Deref>>,
+    stack: &mut std::sync::MutexGuard<BTreeMap<u64, Deref>>,
     next_write: &mut Vec<String>,
     written: &mut VecDeque<Written>,
     memory_map_arc: &Arc<Mutex<Option<Vec<MemoryMapping>>>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs::{self, File};
 use std::io::{BufReader, Read, Write};
 use std::net::{SocketAddr, TcpStream};
@@ -172,7 +172,7 @@ struct App {
     register_names: Arc<Mutex<Vec<String>>>,
     registers: Arc<Mutex<Vec<RegisterStorage>>>,
     /// Saved Stack
-    stack: Arc<Mutex<HashMap<u64, Deref>>>,
+    stack: Arc<Mutex<BTreeMap<u64, Deref>>>,
     /// Saved ASM
     asm: Arc<Mutex<Vec<Asm>>>,
     /// Hexdump
@@ -245,7 +245,7 @@ impl App {
             register_changed: Arc::new(Mutex::new(vec![])),
             register_names: Arc::new(Mutex::new(vec![])),
             registers: Arc::new(Mutex::new(vec![])),
-            stack: Arc::new(Mutex::new(HashMap::new())),
+            stack: Arc::new(Mutex::new(BTreeMap::new())),
             asm: Arc::new(Mutex::new(Vec::new())),
             hexdump: Arc::new(Mutex::new(None)),
             hexdump_scroll: 0,

--- a/src/ui/asm.rs
+++ b/src/ui/asm.rs
@@ -16,11 +16,10 @@ pub fn draw_asm(app: &App, f: &mut Frame, asm: Rect) {
     let mut function_name = None;
     let mut tallest_function_len = 0;
 
+    // Display asm, this will already be in a sorted order
     if let Ok(asm) = app.asm.lock() {
-        let mut entries: Vec<_> = asm.clone().into_iter().collect();
-        entries.sort_by(|a, b| a.address.cmp(&b.address));
         let app_cur_lock = app.current_pc.lock().unwrap();
-        for (index, a) in entries.iter().enumerate() {
+        for (index, a) in asm.iter().enumerate() {
             if a.address == *app_cur_lock {
                 pc_index = Some(index);
                 if let Some(func_name) = &a.func_name {

--- a/src/ui/stack.rs
+++ b/src/ui/stack.rs
@@ -16,9 +16,7 @@ pub fn draw_stack(app: &App, f: &mut Frame, stack: Rect) {
     let width: usize = if app.thirty_two_bit.load(Ordering::Relaxed) { 11 } else { 19 };
 
     if let Ok(stack) = app.stack.lock() {
-        let mut entries: Vec<_> = stack.clone().into_iter().collect();
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
-        for (addr, values) in entries.iter() {
+        for (addr, values) in stack.iter() {
             let filepath_lock = app.filepath.lock().unwrap();
             let binding = filepath_lock.as_ref().unwrap();
             let filepath = binding.to_string_lossy();


### PR DESCRIPTION
* Use BTreeMap for stack, so that they are sorted already
* Asm is already sorted when we get results back