### PR TITLE
Remove panic on empty memory map

### DIFF
--- a/src/gdb/exec_result/recv/changed_registers.rs
+++ b/src/gdb/exec_result/recv/changed_registers.rs
@@ -3,10 +3,10 @@ use crate::mi::parse_register_names_values;
 /// `MIResponse::ExecResult`, key: "changed-registers"
 pub fn recv_exec_result_changed_registers(
     changed_registers: &String,
-    register_changed: &mut Vec<u8>,
+    register_changed: &mut Vec<u16>,
 ) {
     let changed_registers = parse_register_names_values(changed_registers);
-    let result: Vec<u8> =
-        changed_registers.iter().map(|s| s.parse::<u8>().expect("Invalid number")).collect();
+    let result: Vec<u16> =
+        changed_registers.iter().map(|s| s.parse::<u16>().expect("Invalid number")).collect();
     *register_changed = result;
 }

--- a/src/gdb/stream_output.rs
+++ b/src/gdb/stream_output.rs
@@ -50,6 +50,12 @@ pub fn stream_output(
         // effect of not having a GDB MI way of getting a memory map
         return;
     }
+
+    if s.contains("warning: unable to open /proc file '/proc/1/maps'") {
+        log::trace!("proc file could not be read, abort memory map reading");
+        return;
+    }
+
     let split: Vec<&str> = s.split_whitespace().collect();
     if split == MEMORY_MAP_START_STR_NEW {
         current_map.0 = Some(Mapping::New);

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ struct Args {
     log_path: Option<String>,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 enum Mode {
     All,
     OnlyRegister,
@@ -155,7 +155,7 @@ struct StateShare {
     state: Arc<Mutex<State>>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 struct Scroll {
     scroll: usize,
     state: ScrollbarState,
@@ -189,7 +189,7 @@ impl Scroll {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct State {
     /// Messages to write to gdb mi
     next_write: Vec<String>,
@@ -220,7 +220,7 @@ struct State {
     /// Saved output such as (gdb) or > from gdb
     stream_output_prompt: String,
     /// Register TUI
-    register_changed: Vec<u8>,
+    register_changed: Vec<u16>,
     register_names: Vec<String>,
     registers: Vec<RegisterStorage>,
     registers_scroll: Scroll,

--- a/src/ui/registers.rs
+++ b/src/ui/registers.rs
@@ -52,7 +52,7 @@ pub fn draw_registers(state: &mut State, f: &mut Frame, register: Rect) {
             }
             if let Some(reg_value) = &reg.value {
                 if let Ok(val) = u64::from_str_radix(&reg_value[2..], 16) {
-                    let changed = state.register_changed.contains(&(i as u8));
+                    let changed = state.register_changed.contains(&(i as u16));
                     let mut reg_name =
                         Span::from(format!("  {name:width$}", width = longest_register_name))
                             .style(Style::new().fg(PURPLE));

--- a/src/ui/stack.rs
+++ b/src/ui/stack.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ratatui::prelude::Stylize;
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Paragraph};
@@ -15,7 +17,7 @@ pub fn draw_stack(state: &mut State, f: &mut Frame, stack: Rect) {
 
     let stacks = state.stack.clone();
     for (addr, values) in stacks.iter() {
-        let filepath = state.filepath.clone().unwrap();
+        let filepath = state.filepath.clone().unwrap_or(PathBuf::new());
         let filepath = filepath.to_string_lossy();
 
         let hex_string = format!("0x{:02x}", addr);


### PR DESCRIPTION
* Support devices with registers > 255
* Support devices with no memory map

This patch was tested on my esp32-c3 (risc-v)